### PR TITLE
fix(cp0): correct STRDUMP operands

### DIFF
--- a/cp0.json
+++ b/cp0.json
@@ -684,8 +684,8 @@
       "doc_stack": "-",
       "mnemonic": "STRDUMP",
       "operands": {
-        "i": 0,
-        "j": 0
+        "i": 1,
+        "j": 4
       }
     },
     {


### PR DESCRIPTION
https://github.com/ton-blockchain/ton/blob/e40d323fcef788123390038bce10a9845014e8ed/crypto/vm/debugops.cpp#L154C9-L154C79
```
.insert(OpcodeInstr::mksimple(0xfe14, 16,"STRDUMP", exec_dump_string))
```
